### PR TITLE
Suppress heat warning 5150

### DIFF
--- a/wix/index.go
+++ b/wix/index.go
@@ -18,7 +18,7 @@ func GenerateCmd(wixFile *manifest.WixManifest, templates []string, msiOutFile, 
 	for i, dir := range wixFile.RelDirs {
 		sI := strconv.Itoa(i)
 		cmd += filepath.Join(path, "heat") + " dir " + dir + " -nologo -cg AppFiles" + sI
-		cmd += " -ag -gg -g1 -srd -sfrag -template fragment -dr APPDIR" + sI
+		cmd += " -ag -gg -g1 -srd -sfrag -sw5150 -template fragment -dr APPDIR" + sI
 		cmd += " -var var.SourceDir" + sI
 		cmd += " -out AppFiles" + sI + ".wxs"
 		cmd += eol


### PR DESCRIPTION
```
heat.exe : warning HEAT5150 : Could not harvest data from a file that was expected to be a SelfReg DLL: C:\Somewhere\Something.exe. If this file does not support SelfReg you can ignore this warning. Otherwise, this error detail may be helpful to diagnose the failure: ...
```